### PR TITLE
Fix linking for current cc65 version

### DIFF
--- a/hello_world.cfg
+++ b/hello_world.cfg
@@ -54,7 +54,7 @@ SEGMENTS {
 
 # We'll put the C stack in page one ($0100-$01ff).
 SYMBOLS {
-    __STACK_START__: type = weak, value = $0100;
-    __STACK_SIZE__:  type = weak, value = $100;
+    __STACK_START__: value = $0100, weak = yes;
+    __STACK_SIZE__:  value = $100, weak = yes;
 }
 


### PR DESCRIPTION
Syntax for defining Symbols in the configuration file is different for the current cc65 version (2.13.3)

See: http://www.cc65.org/doc/ld65-5.html#ss5.10
